### PR TITLE
fix double undescore in platinum chain preventing boot with latest gtm

### DIFF
--- a/src/main/java/argent_matter/gtec/common/data/GTECMaterials.java
+++ b/src/main/java/argent_matter/gtec/common/data/GTECMaterials.java
@@ -59,7 +59,7 @@ public class GTECMaterials {
             .color(0xF0EC9A).iconSet(MaterialIconSet.BRIGHT)
             .buildAndRegister();
 
-    public static final Material ReprecipitatedPlatinum = new Material.Builder(GTExtendedChem.id("reprecipitated__platinum"))
+    public static final Material ReprecipitatedPlatinum = new Material.Builder(GTExtendedChem.id("reprecipitated_platinum"))
             .dust(1)
             .color(0xF0EC9A).iconSet(MaterialIconSet.BRIGHT)
             .buildAndRegister()


### PR DESCRIPTION
Seems my last change introduced a bug here.  Not sure if this error was overlooked in previous versions of GTM or simply did not work, but this fixes it.