### PR TITLE
zinc sulfate reprocessing

### DIFF
--- a/src/main/java/argent_matter/gtec/common/data/GTECMaterials.java
+++ b/src/main/java/argent_matter/gtec/common/data/GTECMaterials.java
@@ -59,7 +59,7 @@ public class GTECMaterials {
             .color(0xF0EC9A).iconSet(MaterialIconSet.BRIGHT)
             .buildAndRegister();
 
-    public static final Material ReprecipitatedPlatinum = new Material.Builder(GTExtendedChem.id("reprecipitated__platinum"))
+    public static final Material ReprecipitatedPlatinum = new Material.Builder(GTExtendedChem.id("reprecipitated_platinum"))
             .dust(1)
             .color(0xF0EC9A).iconSet(MaterialIconSet.BRIGHT)
             .buildAndRegister()

--- a/src/main/java/argent_matter/gtec/common/data/GTECMaterials.java
+++ b/src/main/java/argent_matter/gtec/common/data/GTECMaterials.java
@@ -130,6 +130,8 @@ public class GTECMaterials {
     public static final Material ZincSulfate = new Material.Builder(GTExtendedChem.id("zinc_sulfate"))
             .dust(1)
             .color(0x7C4D0E).iconSet(METALLIC)
+            .flags(DECOMPOSITION_BY_ELECTROLYZING)
+            .components(Zinc, 1, Sulfur, 1, Oxygen, 4)
             .buildAndRegister()
             .setFormula("ZnSO4", true);
 

--- a/src/main/java/argent_matter/gtec/data/recipe/PlatinumLineRecipes.java
+++ b/src/main/java/argent_matter/gtec/data/recipe/PlatinumLineRecipes.java
@@ -254,6 +254,15 @@ public class PlatinumLineRecipes {
                 .outputItems(dust, GTECMaterials.ReprecipitatedRhodium,1)
                 .duration(300).EUt(VA[LV]).save(provider);
 
+        // Zinc Sulfate reprocessing
+
+        CHEMICAL_RECIPES.recipeBuilder(GTExtendedChem.id("zinc_sulfate"))
+                .inputItems(dust, GTECMaterials.ZincSulfate, 6)
+                .inputFluids(Hydrogen.getFluid(2000))
+                .outputItems(dust, Zinc, 1)
+                .outputFluids(SulfuricAcid.getFluid(1000))
+                .duration(30).EUt(VA[ULV]).save(provider);
+
         // Rhodium Dust Output <------------ Third Platline Dust also holy shit
 
         CHEMICAL_RECIPES.recipeBuilder("rhodium_dust")


### PR DESCRIPTION
Added a chem-reactor version (from nh) and also enabled standard electrolyzer decomposition.  Addresses one of the take aways from #2 and one of the last missing bits from the platline.

This includes #3 because testing without it was not possible.