### PR TITLE
more platline fixes

### DIFF
--- a/src/main/java/argent_matter/gtec/data/recipe/disabled/PlatinumLineRecipes.java
+++ b/src/main/java/argent_matter/gtec/data/recipe/disabled/PlatinumLineRecipes.java
@@ -61,7 +61,7 @@ public class PlatinumLineRecipes {
 
         CHEMICAL_RECIPES.recipeBuilder(GTExtendedChem.id("dissolve_tetrahedrite_for_platline"))
                 .inputItems(crushedPurified, Tetrahedrite,9)
-                .inputItems(dust, GTECMaterials.PlatinumMetallicPowder)
+                .inputItems(dust, GTECMaterials.PlatinumMetallicPowder,9)
                 .inputFluids(AquaRegia.getFluid(10000))
                 .outputItems(dust, GTECMaterials.PlatinumResidue)
                 .outputFluids(GTECMaterials.PlatinumConcentrate.getFluid(10000))
@@ -558,5 +558,3 @@ public class PlatinumLineRecipes {
                 .duration(600).EUt(VA[LV]).save(provider);
     }
 }
-
-

--- a/src/main/java/argent_matter/gtec/data/recipe/disabled/PlatinumLineRecipes.java
+++ b/src/main/java/argent_matter/gtec/data/recipe/disabled/PlatinumLineRecipes.java
@@ -382,22 +382,22 @@ public class PlatinumLineRecipes {
         // Remaining Sifting Recipes
         SIFTER_RECIPES.recipeBuilder(GTExtendedChem.id("refined_platinum_salt"))
                         .inputItems(dust, GTECMaterials.PlatinumSalt,1)
-                .chancedOutput(dust, GTECMaterials.RefinedPlatlinumSalt, 1000,0)
-                .chancedOutput(dust, GTECMaterials.RefinedPlatlinumSalt, 1000,0)
-                .chancedOutput(dust, GTECMaterials.RefinedPlatlinumSalt, 1000,0)
-                .chancedOutput(dust, GTECMaterials.RefinedPlatlinumSalt, 1000,0)
-                .chancedOutput(dust, GTECMaterials.RefinedPlatlinumSalt, 1000,0)
                 .chancedOutput(dust, GTECMaterials.RefinedPlatlinumSalt, 1500,0)
+                .chancedOutput(dust, GTECMaterials.RefinedPlatlinumSalt, 1500,0)
+                .chancedOutput(dust, GTECMaterials.RefinedPlatlinumSalt, 1500,0)
+                .chancedOutput(dust, GTECMaterials.RefinedPlatlinumSalt, 1500,0)
+                .chancedOutput(dust, GTECMaterials.RefinedPlatlinumSalt, 1500,0)
+                .chancedOutput(dust, GTECMaterials.RefinedPlatlinumSalt, 2000,0)
                 .duration(600).EUt(VA[LV]).save(provider);
 
         SIFTER_RECIPES.recipeBuilder(GTExtendedChem.id("salt_to_metallic_powder_palladium"))
                 .inputItems(dust, GTECMaterials.PalladiumSalt,1)
-                .chancedOutput(dust, GTECMaterials.PalladiumMetallicPowder, 1000,0)
-                .chancedOutput(dust, GTECMaterials.PalladiumMetallicPowder, 1000,0)
-                .chancedOutput(dust, GTECMaterials.PalladiumMetallicPowder, 1000,0)
-                .chancedOutput(dust, GTECMaterials.PalladiumMetallicPowder, 1000,0)
-                .chancedOutput(dust, GTECMaterials.PalladiumMetallicPowder, 1000,0)
                 .chancedOutput(dust, GTECMaterials.PalladiumMetallicPowder, 1500,0)
+                .chancedOutput(dust, GTECMaterials.PalladiumMetallicPowder, 1500,0)
+                .chancedOutput(dust, GTECMaterials.PalladiumMetallicPowder, 1500,0)
+                .chancedOutput(dust, GTECMaterials.PalladiumMetallicPowder, 1500,0)
+                .chancedOutput(dust, GTECMaterials.PalladiumMetallicPowder, 1500,0)
+                .chancedOutput(dust, GTECMaterials.PalladiumMetallicPowder, 2000,0)
                 .duration(600).EUt(VA[LV]).save(provider);
 
 

--- a/src/main/java/argent_matter/gtec/data/recipe/disabled/PlatinumLineRecipes.java
+++ b/src/main/java/argent_matter/gtec/data/recipe/disabled/PlatinumLineRecipes.java
@@ -156,6 +156,7 @@ public class PlatinumLineRecipes {
                 .circuitMeta(2)
                 .inputItems(dustSmall, GTECMaterials.PotassiumDisulfate, 2)
                 .outputFluids(RhodiumSulfate.getFluid(360))
+                .outputItems(dust, GTECMaterials.LeachResidue, 1)
                 .blastFurnaceTemp(775)
                 .duration(200).EUt(VA[MV]).save(provider);
 


### PR DESCRIPTION
A player has reported two things:
1. the yields of the platline are very low
2. tetrahedrite is suspiciously incredibly good at creating platinum concentrate

That 2nd point seems like an oversight and is fixed in the first commit.

Regarding the yields, I've looked a little closer. Indeed, they're even lower than GTNH for several reasons.

1. only sheldonite and nickel get you Platinum Metallic Powder (pmp) and get you into the plat chain..  in GTNH there's a PMP ore which yields pmp directly, which helps for platline byproducts..  GTEC could add pmp ore, but for my purposes I can fix this w/ KJS by altering platinum ore.
2. nickel ore bathed in mercury gets you 1x pmp @ 70% yield in gtec vs 2x @ 70% in gtnh..  but this is only meant as a _very_ early bootstrap so I don't think it's typical to run this
3. sheldonite cannot produce pmp directly; instead you get dust which has a 6x -> 3x pmp yield, or 1 per ore... gtnh lets you wash sheldonite for 70% extra pmp yield in mercury, or for 4x @ 11.11% palladium metallic powder (plmp)
4. platinum salt + palladium salt sift at a 65% total for feeding back into the chain (refined salt -> pmp/plmp) in gtec, but 95% in gtnh because that sifter has 9 chanced outputs to gtm's 6. This is a huge reduction in the number of loops you can run before you have to supply more sheldonite.
5. Blasting PlatinumResidue in GTNH gets you 1x leach residue + 360L of Rhodium sulfate, which can then be processed into a tiny bit more leach residue + rhodium...  but in GTEC you do not get that 1x leach residue dust, which is roughly a 30x nerf to Iridium/Osmium/Ruthenium output.

4 and 5 are _big_.  After 3 routes through the platline/palladium ammonia line, you still have 85.7% of your inputs through recycling salt dusts GTNH, but in gtec that number is 27.4%.  You can run the GTNH lines 25 times before your product gets that low.  This works out to roughly a 9x nerf on the entire line.

The 2nd commit adjusts the chanced outputs on the sifter to be 15/15/15/15/20%, which should bring the recycling yields back on par with GTNH's (8x 10%, 1x 15%).

For 5, this seems like an oversight, and that's fixed in commit 3.  

Together, these changes increase the output of Ir/Ru/Os/Rh 180x, and Platinum/Palladium 9x.